### PR TITLE
A bit more MSVC compatibility

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -867,10 +867,10 @@ detexConversionType detex_conversion_table[] = {
 
 // #define TRACE_MATCH_CONVERSION
 
-static __thread uint32_t cached_source_format = -1;
-static __thread uint32_t cached_target_format = -1;
-static __thread int cached_nu_conversions = - 1;
-static __thread uint32_t cached_conversion[4];
+static DETEX_THREAD uint32_t cached_source_format = -1;
+static DETEX_THREAD uint32_t cached_target_format = -1;
+static DETEX_THREAD int cached_nu_conversions = - 1;
+static DETEX_THREAD uint32_t cached_conversion[4];
 
 static void CacheResult(uint32_t source_format, uint32_t target_format, int n, uint32_t *conversion) {
 	cached_source_format = source_format;

--- a/detex.h
+++ b/detex.h
@@ -74,9 +74,12 @@ __BEGIN_DECLS
 
 #if _MSC_VER
 #define DETEX_INLINE_ONLY __forceinline
+#define DETEX_THREAD __declspec(thread)
 #else
+#define DETEX_THREAD __thread
 #define DETEX_INLINE_ONLY __attribute__((always_inline)) inline
 #endif
+
 #define DETEX_RESTRICT __restrict
 
 /* Maximum uncompressed block size in bytes. */

--- a/hdr.c
+++ b/hdr.c
@@ -29,11 +29,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 // Gamma/HDR parameters.
 
-__thread float detex_gamma = 1.0f;
-__thread float detex_gamma_range_min = 0.0f;
-__thread float detex_gamma_range_max = 1.0f;
-__thread float *detex_gamma_corrected_half_float_table = NULL;
-__thread float detex_corrected_half_float_table_gamma;
+DETEX_THREAD float detex_gamma = 1.0f;
+DETEX_THREAD float detex_gamma_range_min = 0.0f;
+DETEX_THREAD float detex_gamma_range_max = 1.0f;
+DETEX_THREAD float *detex_gamma_corrected_half_float_table = NULL;
+DETEX_THREAD float detex_corrected_half_float_table_gamma;
 
 void detexSetHDRParameters(float gamma, float range_min, float range_max) {
 	detex_gamma = gamma;

--- a/misc.c
+++ b/misc.c
@@ -94,7 +94,7 @@ end:
 
 // Error handling.
 
-static __thread char *detex_error_message = NULL;
+static DETEX_THREAD char *detex_error_message = NULL;
 
 void detexSetErrorMessage(const char *format, ...) {
 	if (detex_error_message != NULL)


### PR DESCRIPTION
For some reason MSVC 2019 were complaining about __thread being to recognized, so I've moved it into define, linux built should not be affected, for windows it will be replaced with __declspec(thread)